### PR TITLE
Show position tags in trade preview chips

### DIFF
--- a/DH-HQ_v3.1/scripts/app.js
+++ b/DH-HQ_v3.1/scripts/app.js
@@ -419,7 +419,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             const teamName = assetRow.closest('.roster-column')?.dataset.teamName;
             if (!teamName || !state.teamsToCompare.has(teamName)) return;
 
-            const { assetId, assetLabel, assetKtc } = assetRow.dataset;
+            const { assetId, assetLabel, assetKtc, assetPos } = assetRow.dataset;
             if (!assetId) return;
 
             if (!state.tradeBlock[teamName]) {
@@ -435,7 +435,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 state.tradeBlock[teamName].push({
                     id: assetId,
                     label: assetLabel,
-                    ktc: parseInt(assetKtc, 10) || 0
+                    ktc: parseInt(assetKtc, 10) || 0,
+                    pos: assetPos
                 });
                 assetRow.classList.add('player-selected');
             }
@@ -835,9 +836,12 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         function createPlayerRow(player, teamName) {
             const row = document.createElement('div');
             row.className = 'player-row';
+            const slotAbbr = { 'SUPER_FLEX': 'SFLX', 'FLEX': 'FLX' };
+            const displaySlot = state.currentRosterView === 'depth' ? (slotAbbr[player.slot] || player.slot) : player.pos;
             row.dataset.assetId = player.id;
             row.dataset.assetLabel = player.name;
             row.dataset.assetKtc = player.ktc || 0;
+            row.dataset.assetPos = displaySlot;
 
             if (state.tradeBlock[teamName]?.find(a => a.id === player.id)) {
                 row.classList.add('player-selected');
@@ -845,8 +849,6 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
             const adp = player.adp ? player.adp.toFixed(1) : '—';
             const ktc = player.ktc || '—';
-            const slotAbbr = { 'SUPER_FLEX': 'SFLX', 'FLEX': 'FLX' };
-            const displaySlot = state.currentRosterView === 'depth' ? (slotAbbr[player.slot] || player.slot) : player.pos;
             const teamTagHTML = player.team && player.team !== 'FA' 
                 ? `<div class="team-tag" style="background-color: ${TEAM_COLORS[player.team] || '#64748b'}; color: white; text-shadow: 1px 1px 2px rgba(0,0,0,0.5);">${player.team}</div>` 
                 : `<div class="team-tag" style="background-color: #64748b; color: white;">${player.team || 'FA'}</div>`;
@@ -961,7 +963,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 if (assets.length > 0) {
                     assets.forEach(asset => {
                         const ktcColor = getKtcColor(asset.ktc);
-                        assetsHTML += `<div class="trade-asset-chip"><span>${asset.label}</span><span class="ktc" style="color: ${ktcColor}">(${asset.ktc})</span></div>`;
+                        const tagColor = TAG_COLORS[asset.pos] || 'var(--pos-bn)';
+                        assetsHTML += `<div class="trade-asset-chip"><span class="player-tag" style="background-color: ${tagColor};">${asset.pos}</span><span>${asset.label}</span><span class="ktc" style="color: ${ktcColor}">(${asset.ktc})</span></div>`;
                     });
                 } else {
                     assetsHTML = `<span class="text-xs text-slate-500 p-2">Select assets...</span>`;

--- a/DH-HQ_v3.1/styles/styles.css
+++ b/DH-HQ_v3.1/styles/styles.css
@@ -960,7 +960,11 @@
             text-align: center;
             color: var(--color-text-secondary);
         }
-        .trade-asset-chip .ktc { 
+        .trade-asset-chip .player-tag {
+            font-size: 0.55rem;
+            padding: 1px 3px;
+        }
+        .trade-asset-chip .ktc {
             font-weight: 700;
             color: var(--color-text-primary);
         }


### PR DESCRIPTION
## Summary
- Store each selected player's position alongside trade assets
- Render position tag before player name in trade preview chips
- Tweak trade preview styles for tighter position tags

## Testing
- `node --check scripts/app.js`
- `npm test` *(fails: ENOENT, package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd41567ee4832e8b98a7ac1453018a